### PR TITLE
Fix imdsv2 token fetch method

### DIFF
--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -72,7 +72,7 @@ impl Aws {
         };
 
         let token = match client
-            .get(token_url)
+            .put(token_url)
             .header("X-aws-ec2-metadata-token-ttl-seconds", "60")
             .send()
             .await


### PR DESCRIPTION
Replaces `.get(token_url)` with `.put(token_url)` per AWS IMDSv2 requirements.
Fixes failures on Windows - we don't have local paths to determine the AWS like we do in linux (PRODUCT_VERSION file and BIOS_VERSION file aren't available).